### PR TITLE
Support for indent-guide and invisible-character

### DIFF
--- a/index.less
+++ b/index.less
@@ -176,3 +176,8 @@
 .meta.selector.css, .entity.name.tag.css, .meta.selector.css, .entity.other.attribute-name.class, .meta.selector.css, .entity.other.attribute-name.id, .entity.other.attribute-name.pseudo-element.css, .entity.other.attribute-name.pseudo-class.css, .source.css, .meta.selector.css, .entity.other.attribute-name.pseudo-class.css, .punctuation.separator.key-value, .punctuation.terminator.rule.css {
   color: #34d58e;
 }
+
+.indent-guide,
+.invisible-character {
+  color: #295b75;
+}


### PR DESCRIPTION
Currently when you enable "Show Indent Guide" and "Show Invisibles" in Settings, the colors are very bright. This update adds a dark navy color for those elements to push them to the background.

Thanks for putting this together btw!
